### PR TITLE
feat: Add Support for Text Messages in Stats

### DIFF
--- a/src/main/java/com/mobiera/ms/commons/stats/jms/StatQueueConsumer.java
+++ b/src/main/java/com/mobiera/ms/commons/stats/jms/StatQueueConsumer.java
@@ -246,7 +246,7 @@ public class StatQueueConsumer {
     										
     									}
             	                	}
-											sendEvent(uuid, now, event, context);
+											processStatEvent(uuid, now, event, context);
         						} else if (message instanceof TextMessage) {
 											ObjectMapper objectMapper = new ObjectMapper();
 											TextMessage txtMsg = (TextMessage) message;
@@ -271,7 +271,7 @@ public class StatQueueConsumer {
 											event.setIncrement(rootNode.path("increment").asInt(0));
 											event.setDoubleIncrement(rootNode.path("doubleIncrement").asDouble(0.0));
 											event.setEnums(enums);
-											sendEvent(uuid, now, event, context);
+											processStatEvent(uuid, now, event, context);
         						} else {
         							if (debug) logger.warn("statConsumer " + queueName + " "+ uuid + " " + (System.currentTimeMillis() - now)+ ": unkown event " + event);
         							context.commit();
@@ -352,7 +352,7 @@ public class StatQueueConsumer {
 	}
 	
 	
-	private void sendEvent(UUID uuid, long now, StatEvent event, JMSContext context) {
+	private void processStatEvent(UUID uuid, long now, StatEvent event, JMSContext context) {
 		try {
 			if (debug) 
 				logger.info("statConsumer: " + queueName + " before stat "+ uuid + " " + (System.currentTimeMillis() - now));

--- a/src/main/java/com/mobiera/ms/commons/stats/jms/StatQueueConsumer.java
+++ b/src/main/java/com/mobiera/ms/commons/stats/jms/StatQueueConsumer.java
@@ -1,7 +1,11 @@
 package com.mobiera.ms.commons.stats.jms;
 
 
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -9,7 +13,10 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mobiera.commons.util.JsonUtil;
+import com.mobiera.ms.commons.stats.api.StatEnum;
 import com.mobiera.ms.commons.stats.api.StatEvent;
 import com.mobiera.ms.commons.stats.svc.StatBuilderService;
 
@@ -28,6 +35,8 @@ import jakarta.jms.Message;
 import jakarta.jms.ObjectMessage;
 import jakarta.jms.Queue;
 import jakarta.jms.Session;
+import jakarta.jms.TextMessage;
+import lombok.Data;
 
 @ApplicationScoped
 public class StatQueueConsumer {
@@ -237,31 +246,32 @@ public class StatQueueConsumer {
     										
     									}
             	                	}
-        							try {
-        								if (debug) 
-        									logger.info("statConsumer: " + queueName + " before stat "+ uuid + " " + (System.currentTimeMillis() - now));
-
-        								getStatBuilderService().statEvent(event);
-        								if (debug) 
-        									logger.info("statConsumer: " + queueName + " after stat, before commit "+ uuid + " " + (System.currentTimeMillis() - now));
-
-        								context.commit();
-        								if (debug) 
-        									logger.info("statConsumer: " + queueName + " after commit "+ uuid + " " + (System.currentTimeMillis() - now));
-
-        								
-        								
-        							} catch (Exception e) {
-        								try {
-        									logger.warn("statConsumer: " + queueName + " "+ uuid + " " + (System.currentTimeMillis() - now)+ ": exception " + JsonUtil.serialize(event, false), e);
-        								} catch (JsonProcessingException e1) {
-        									logger.warn("statConsumer: " + queueName + " "+ uuid + " " + (System.currentTimeMillis() - now)+ ": exception", e);
-        								}
-        								context.rollback();
-        								//if (debug) 
-        								logger.info("statConsumer: " + queueName + " after rollback "+ uuid + " " + (System.currentTimeMillis() - now));
-
-        							} 
+											sendEvent(uuid, now, event, context);
+        						} else if (message instanceof TextMessage) {
+											ObjectMapper objectMapper = new ObjectMapper();
+											TextMessage txtMsg = (TextMessage) message;
+											JsonNode rootNode = objectMapper.readTree(txtMsg.getText());
+											
+											List<StatEnum> enums = new ArrayList<>();
+											rootNode.path("enums").forEach(enumNode -> {
+													try {
+															enums.add(objectMapper.treeToValue(enumNode, StatEnumImpl.class));
+        								} catch (JsonProcessingException e) {
+													}
+											});
+											event = new StatEvent();
+											event.setStatClass(rootNode.path("statClass").asText("null"));
+											event.setEntityId(rootNode.path("entityId").asText("null"));
+											if (!rootNode.path("ts").isMissingNode()) {
+													try {
+															event.setTs(Instant.parse(rootNode.path("ts").asText()));
+													} catch (DateTimeParseException e) {
+													}
+											}
+											event.setIncrement(rootNode.path("increment").asInt(0));
+											event.setDoubleIncrement(rootNode.path("doubleIncrement").asDouble(0.0));
+											event.setEnums(enums);
+											sendEvent(uuid, now, event, context);
         						} else {
         							if (debug) logger.warn("statConsumer " + queueName + " "+ uuid + " " + (System.currentTimeMillis() - now)+ ": unkown event " + event);
         							context.commit();
@@ -342,7 +352,36 @@ public class StatQueueConsumer {
 	}
 	
 	
+	private void sendEvent(UUID uuid, long now, StatEvent event, JMSContext context) {
+		try {
+			if (debug) 
+				logger.info("statConsumer: " + queueName + " before stat "+ uuid + " " + (System.currentTimeMillis() - now));
+
+			getStatBuilderService().statEvent(event);
+			if (debug) 
+				logger.info("statConsumer: " + queueName + " after stat, before commit "+ uuid + " " + (System.currentTimeMillis() - now));
+
+			context.commit();
+			if (debug) 
+				logger.info("statConsumer: " + queueName + " after commit "+ uuid + " " + (System.currentTimeMillis() - now));
+		} catch (Exception e) {
+			try {
+				logger.warn("statConsumer: " + queueName + " "+ uuid + " " + (System.currentTimeMillis() - now)+ ": exception " + JsonUtil.serialize(event, false), e);
+			} catch (JsonProcessingException e1) {
+				logger.warn("statConsumer: " + queueName + " "+ uuid + " " + (System.currentTimeMillis() - now)+ ": exception", e);
+			}
+			context.rollback();
+			logger.info("statConsumer: " + queueName + " after rollback "+ uuid + " " + (System.currentTimeMillis() - now));
+		}
+	}
 	
+	@Data
+	public static class StatEnumImpl implements StatEnum {
+    private Integer index;
+    private String label;
+    private String value;
+    private String description;
+	}
 	
     
    


### PR DESCRIPTION
To enable the use of the statistics module in chatbots developed with the SDK on Node.js or any other language in the future, it is necessary to implement support for messages received from Artemis queues that are not exclusively of type `ObjectMessage`. According to the documentation [IBM MQ Documentation](https://www.ibm.com/docs/en/ibm-mq/9.1?topic=messages-jms-message-body), these messages are specific to Java serialization. Therefore, there is a need to implement support for `TextMessage` messages sent by the queues, ensuring that the module can be seamlessly used in other scenarios.

**Implemented Changes:**
1. Structuring repetitive code into a method (`processStatEvent`) available for both message types with their respective validations.
2. Creation of the static class `StatEnumImpl` to interpret the object within the `StatEvent` class.
3. Handling of the `TextMessage` type by reading and processing each parameter accordingly.  