### PR TITLE
build: upgrade to Quarkus 3.35.3 / Java 25 (match pm-model)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,15 +28,16 @@
       <url>https://github.com/mobiera/service-log-api/tree/main</url>
    </scm>
   <properties>
-    <compiler-plugin.version>3.8.1</compiler-plugin.version>
+    <compiler-plugin.version>3.13.0</compiler-plugin.version>
     <failsafe.useModulePath>false</failsafe.useModulePath>
-    <maven.compiler.release>11</maven.compiler.release>
+    <lombok.version>1.18.42</lombok.version>
+    <maven.compiler.release>25</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.6.8</quarkus.platform.version>
-    <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+    <quarkus.platform.version>3.35.3</quarkus.platform.version>
+    <surefire-plugin.version>3.5.2</surefire-plugin.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -80,7 +81,7 @@
     </dependency>
     <dependency>
     <groupId>io.quarkus</groupId>
-    <artifactId>quarkus-rest-client</artifactId>
+    <artifactId>quarkus-resteasy-client</artifactId>
 </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
@@ -97,12 +98,12 @@
    <dependency>
       <groupId>io.quarkiverse.artemis</groupId>
       <artifactId>quarkus-artemis-core</artifactId>
-      <version>3.1.3</version>
+      <version>3.10.2</version>
     </dependency>
     <dependency>
       <groupId>io.quarkiverse.artemis</groupId>
       <artifactId>quarkus-artemis-jms</artifactId>
-      <version>3.1.3</version>
+      <version>3.10.2</version>
     </dependency>
      <dependency>
       <groupId>org.graalvm.sdk</groupId>
@@ -122,7 +123,7 @@
   <dependency>
     <groupId>org.projectlombok</groupId>
     <artifactId>lombok</artifactId>
-    <version>1.18.30</version>
+    <version>${lombok.version}</version>
     <scope>provided</scope>
   </dependency>
    
@@ -168,6 +169,13 @@
           <compilerArgs>
             <arg>-parameters</arg>
           </compilerArgs>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>org.projectlombok</groupId>
+              <artifactId>lombok</artifactId>
+              <version>${lombok.version}</version>
+            </path>
+          </annotationProcessorPaths>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
## What

Bring `stats` to the same platform as `mno-adapters-pm-model`:

| | before | after |
|---|---|---|
| `quarkus.platform.version` | 3.6.8 | **3.35.3** |
| `maven.compiler.release` | 11 | **25** |
| `compiler-plugin.version` | 3.8.1 | **3.13.0** |
| `surefire-plugin.version` | 3.0.0-M5 | **3.5.2** |
| Artemis extension | 3.1.3 | **3.10.2** |
| Lombok | 1.18.30 | **1.18.42** |

## Required side-changes to make it build

- **Lombok in `annotationProcessorPaths`** — JDK 23+ no longer runs annotation processors found only on the classpath, so without this every Lombok getter/setter resolved as `cannot find symbol`. Lombok also had to move to 1.18.42 (JDK 25 support).
- **`quarkus-rest-client` → `quarkus-resteasy-client`** — the project uses the classic `quarkus-resteasy` server; in 3.35 keeping the reactive client triggers *"Mixing Quarkus REST and RESTEasy Classic server parts is not supported"*. The classic client matches pm-model and keeps the (otherwise unused) `@RestClient` import valid.

## Verification

`mvn -B -ntp -DskipTests clean package` → **BUILD SUCCESS** locally on Temurin/Homebrew JDK 25.0.3 + Maven 3.9.16 (`target/quarkus-app/quarkus-run.jar` produced). Container-image build/push step is unrelated (registry auth).

## Context

Prepares `stats` for the per-operation Helm deployment (`aircast-operation-deployment-template`). Companion to the Artemis multi-instance PR (#11).