### PR TITLE
fix: rewrite README as proper container documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,40 +1,86 @@
-# STATS Project Documentation
-The STATS project, developed by `MOBIERA SAS`, is designed to handle statistics in conjunction with dependencies like STATS-API and mobiera-commons. Importing these dependencies is explained below. The STATS module manages statistics, STATS-API acts as an interface between the service and the statistics module, and mobiera-commons provides general components.
+# stats
 
-## Configuration in application.properties
-Ensure the following properties in the `application.properties` file are updated for the STATS project:
+A scalable [Quarkus](https://quarkus.io/) container that centralizes service statistics.
 
+It consumes statistic events from an ActiveMQ Artemis queue, aggregates them into time‑bucketed counters (hour / day / month) per *stat class* and *entity*, persists them in PostgreSQL, and exposes a read‑only REST API to query and compare those counters.
+
+## Architecture
+
+```text
+  producers (other services)
+        │  StatEvent
+        ▼
+  Artemis queue "stats-queue"  (replicated across 1..8 broker instances)
+        │
+        ▼
+  stats container ──► aggregates ──► PostgreSQL ("stat" table)
+        │
+        ▼
+  REST query API (/stats/*) + Swagger UI
 ```
-com.mobiera.ms.commons.stats.standalone=true - Set to true since the library is part of another project and works as an independent module
-com.mobiera.ms.commons.stats.threads=32 - The number of threads; consider resource consumption
-quarkus.datasource.db-kind - Database kind, preferably postgres
-quarkus.datasource.username - Database username
-quarkus.datasource.password - Database password
-quarkus.datasource.jdbc.url - Database URL
-com.mobiera.ms.commons.stats.debug - Set to true to activate logging
-com.mobiera.ms.commons.stats.jms.queue.name - set the queue name
-```
 
-## Artemis configuration
+- **Ingest**: a multi‑threaded JMS consumer reads `StatEvent` messages from `stats-queue` and increments the matching counters.
+- **Aggregation**: each event targets a *stat class* (e.g. `ANIMATOR`), an *entity id* (preferably a UUID) and one or more *stat enums* (the individual counters). Values are accumulated per granularity (`HOUR`, `DAY`, `MONTH`).
+- **Storage**: counters are stored in the `stat` table (one row per stat class / entity / granularity / timestamp), keyed by a deterministic id.
+- **Query**: clients call the REST API to read, sum or compare counters over a time range.
 
+## Requirements
 
-You can configure until 8 Artemis servers for queues. You need to decide globally for your project and all mno-adapters deployed for this project MUST share the same configuration.
+- Java 25 (the container image is built from `maven:3-eclipse-temurin-25`)
+- Maven (a wrapper `./mvnw` is provided)
+- PostgreSQL
+- ActiveMQ Artemis (shared with the rest of the platform)
 
-All queues are replicated across all instances.
+## Configuration
 
-**Note**: Ensure that the Artemis credentials in your project can connect with the configured credentials.
+Configuration is provided through `src/main/resources/application.properties` and can be overridden with environment variables.
 
-### Define the number of required instances
+### Application
 
-Select from 1 to 8.
+| Property | Env var | Default | Description |
+|----------|---------|---------|-------------|
+| `quarkus.http.port` | `QUARKUS_HTTP_PORT` | `8700` (dev) | HTTP port. |
+| `com.mobiera.ms.commons.app.name` | — | `STATS` | Application name used in logs. |
+| `com.mobiera.ms.commons.stats.threads` | — | `32` | Number of consumer threads (per Artemis instance). Tune to available resources. |
+| `com.mobiera.ms.commons.stats.timezone` | — | `America/Bogota` | Timezone used to compute time buckets. |
+| `com.mobiera.ms.commons.stats.in.memory.past.units` | — | `5` | Number of past units kept in memory for fast accumulation. |
+| `com.mobiera.ms.commons.stats.sleep.per.flush.millis` | — | `60000` | Delay between flushes of in‑memory counters to the database. |
+| `com.mobiera.ms.commons.stats.debug` | — | `false` | Enables verbose logging. |
 
-```
+### Queue
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| `com.mobiera.ms.commons.stats.jms.queue.name` | `stats-queue` | Queue the events are read from. |
+| `com.mobiera.ms.commons.stats.jms.incoming.ttl` | `86400000` | TTL (ms) of incoming messages. |
+| `com.mobiera.ms.commons.stats.jms.retry.delay` | `10000` | Retry delay (ms). |
+| `com.mobiera.ms.commons.stats.jms.ex.delay` | `10000` | Delay (ms) after an exception. |
+| `com.mobiera.artemis.producer.poolsize` | `16` | Producer pool size. |
+
+### Database
+
+| Property | Env var | Description |
+|----------|---------|-------------|
+| `quarkus.datasource.db-kind` | — | Database kind (`postgresql`). |
+| `quarkus.datasource.username` | — | DB username. |
+| `quarkus.datasource.password` | `QUARKUS_DATASOURCE_PASSWORD` | DB password (never commit it). |
+| `quarkus.datasource.jdbc.url` | `QUARKUS_DATASOURCE_JDBC_URL` | JDBC URL. |
+
+The schema is managed by Hibernate (`quarkus.hibernate-orm.database.generation=update`).
+
+### Artemis (1 to 8 instances)
+
+Statistics queues can be spread across **1 to 8 Artemis broker instances**. This decision is **global to the platform**: every Mobiera service (all `mno-adapters-*`, `service-log`, `stats`…) **must share the same Artemis configuration**, because all queues are replicated across all configured instances.
+
+Select the number of instances:
+
+```properties
 com.mobiera.ms.mno.quarkus.artemis.instances=1
 ```
 
-### Configure each instance
+Configure each instance (`a0` … `a7`):
 
-```
+```properties
 quarkus.artemis."a0".url=tcp://artemis:61616
 quarkus.artemis."a0".username=quarkus
 quarkus.artemis."a0".password=...
@@ -42,331 +88,102 @@ quarkus.artemis."a0".password=...
 quarkus.artemis."a1".url=tcp://artemis:61616
 quarkus.artemis."a1".username=quarkus
 quarkus.artemis."a1".password=...
-
-quarkus.artemis."a2".url=tcp://artemis:61616
-quarkus.artemis."a2".username=quarkus
-quarkus.artemis."a2".password=...
-
-quarkus.artemis."a3".url=tcp://artemis:61616
-quarkus.artemis."a3".username=quarkus
-quarkus.artemis."a3".password=...
-
-quarkus.artemis."a4".url=tcp://artemis:61616
-quarkus.artemis."a4".username=quarkus
-quarkus.artemis."a4".password=...
-
-quarkus.artemis."a5".url=tcp://artemis:61616
-quarkus.artemis."a5".username=quarkus
-quarkus.artemis."a5".password=...
-
-quarkus.artemis."a6".url=tcp://artemis:61616
-quarkus.artemis."a6".username=quarkus
-quarkus.artemis."a6".password=...
-
-quarkus.artemis."a7".url=tcp://artemis:61616
-quarkus.artemis."a7".username=quarkus
-quarkus.artemis."a7".password=...
-
+# ... up to a7
 ```
 
-### Kubernetes
+> **Note:** the Artemis credentials configured here must be able to connect to the broker(s).
 
-use:
+On Kubernetes, use the equivalent environment variables:
 
-```
- 
- COM_MOBIERA_MS_MNO_QUARKUS_ARTEMIS_INSTANCES=...
+```bash
+COM_MOBIERA_MS_MNO_QUARKUS_ARTEMIS_INSTANCES=...
 
- QUARKUS_ARTEMIS__A0__URL=...
- QUARKUS_ARTEMIS__A0__USERNAME=...
- QUARKUS_ARTEMIS__A0__PASSWORD=...
- 
- QUARKUS_ARTEMIS__A1__URL=...
- ...
- 
+QUARKUS_ARTEMIS__A0__URL=...
+QUARKUS_ARTEMIS__A0__USERNAME=...
+QUARKUS_ARTEMIS__A0__PASSWORD=...
+
+QUARKUS_ARTEMIS__A1__URL=...
+# ...
 ```
 
+## REST API
 
+The query API is documented with Swagger / OpenAPI. In dev mode the UI is available at:
 
-## Usage
-The STATS project uses Swagger for easy exploration of available endpoints for statistic queries. It is recommended to use a REST client on port 8700 (default) for the following endpoints:
-- stats/view: View statistics; can return cumulative values for better interpretation.
-- stats/compare: Compare statistics.
-- stats/sumLastNStatVO: Sum of statistics over a time interval.
-- stats/get: Get statistics classes by entity type.
-
-## Token Authorization
-To access the STATS-API library from the specified repositories, you need to ensure that the token associated with the `gitlab-maven-microservice-commons-group` matches the one generated for the STATS-API project. Additionally, make sure you have the token for the `gitlab-maven-mobiera-commons-group` project, as the STATS API relies on an existing library from that project. This token can be created either in the `settings.xml` file or as an environment variable for improved security.
-
-## Connection Classes for Artemis
-Two suggested classes for handling the connection with the Artemis module:
-
-- AbstractProducer
-```java
-import java.util.HashMap;
-import java.util.Map;
-
-import jakarta.jms.ConnectionFactory;
-import jakarta.jms.JMSContext;
-import jakarta.jms.JMSProducer;
-import jakarta.jms.Session;
-
-import org.graalvm.collections.Pair;
-import org.jboss.logging.Logger;
-
-
-public class AbstractProducer {
-	
-	private Integer producerId = 0;
-	private Integer producerCount = 8;
-	
-    private Map<Integer,JMSProducer> producers = new HashMap<Integer,JMSProducer>();
-    private Map<Integer,JMSContext> contexts = new HashMap<Integer,JMSContext>();
-    
-	private static final Logger logger = Logger.getLogger(AbstractProducer.class);
-
-	private Object contextLockObj = new Object();
-	
-	protected Pair<Integer, Pair<JMSContext, JMSProducer>> getProducer(ConnectionFactory connectionFactory, boolean debug) {
-    	JMSProducer producer = null;
-    	JMSContext context = null;
-    	int id = 0;
-    	
-    	synchronized (contextLockObj) {
-			if (debug) {
-    			logger.info("spool: with use contexts/producer #" + producerId);
-    		}
-			context = contexts.get(producerId);
-			if (context == null) {
-				context = connectionFactory.createContext(Session.CLIENT_ACKNOWLEDGE);
-				contexts.put(producerId, context);
-			}
-			
-			producer = producers.get(producerId);
-			if (producer == null) {
-				producer = context.createProducer();
-				producers.put(producerId, producer);
-			}
-			id = producerId;
-			producerId++;
-			if (producerId == producerCount) {
-				producerId = 0;
-			}
-		}
-    	return Pair.create(id, Pair.create(context, producer));
-    }
-    
-    protected void purgeAllProducers() {
-    	synchronized (contextLockObj) {
-    		for (int id=0; id<contexts.size(); id++) {
-    			JMSContext context = contexts.get(id);
-        		if (context != null) {
-        			try {
-        	   		 	context.close();
-        	   		 	logger.info("purgeAllProducers: closed producer #" + id);
-     		         } catch (Exception e1) {
-     		         	logger.error("purgeProducer: error closing producer #" + id, e1);
-     		         }
-        		}
-        		contexts.remove(id);
-        		producers.remove(id);
-    		}
-    		
-    		logger.info("purgeAllProducers: remaining contexts size: " + contexts.size() + " producer size: " + producers.size());
-
-    		contexts.clear();
-    		producers.clear();
-    		
-    		logger.info("purgeAllProducers: cleared contexts size: " + contexts.size() + " producer size: " + producers.size());
-    		
-    	}
-    }
-
-	public void setProducerCount(Integer producerCount) {
-		this.producerCount = producerCount;
-	}
-}
+```
+http://localhost:8700/q/swagger-ui/
 ```
 
-- StatProducer
-```java
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.List;
+All endpoints accept and return JSON.
 
-import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.enterprise.event.Observes;
-import jakarta.inject.Inject;
-import jakarta.jms.ConnectionFactory;
-import jakarta.jms.JMSContext;
-import jakarta.jms.JMSException;
-import jakarta.jms.JMSProducer;
-import jakarta.jms.ObjectMessage;
-import jakarta.jms.Queue;
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/stats/view` | Returns a statistics view over a time range. Can return cumulative values. |
+| `POST` | `/stats/compare` | Compares several KPIs over a time range. |
+| `POST` | `/stats/sumLastNStatVO` | Returns the sum of a counter over the last *N* buckets. |
+| `POST` | `/stats/get` | Returns a single counter for a given stat class / entity / granularity / timestamp. |
 
-import org.graalvm.collections.Pair;
-import org.jboss.logging.Logger;
+The granularity (`HOUR`, `DAY`, `MONTH`) is computed automatically from the requested range.
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.mobiera.chatapp.chatbackend.util.ServiceConfig;
-import com.mobiera.commons.util.JsonUtil;
-import com.mobiera.ms.commons.stats.api.CommonStatEnum;
-import com.mobiera.ms.commons.stats.api.StatEnum;
-import com.mobiera.ms.commons.stats.api.StatEvent;
+## Producing statistics
 
-import io.quarkus.runtime.ShutdownEvent;
-import io.quarkus.runtime.StartupEvent;
+Other services publish `StatEvent` messages to `stats-queue`. The typical producer accumulates counters like this:
 
-@ApplicationScoped
-public class StatProducer extends AbstractProducer {
-
-	@Inject
-    ConnectionFactory connectionFactory;
-
-	private static final Logger logger = Logger.getLogger(StatProducer.class);
-	
-	int id = 0;
-    
-    public boolean isDebugEnabled() {
-			return ServiceConfig.DEBUG;
-	}
-    
-    void onStart(@Observes StartupEvent ev) {
-    	logger.info("onStart: queue name " + ServiceConfig.QUEUENAME);
-    	this.setProducerCount(ServiceConfig.POOLSIZE);
-    }
-
-    void onStop(@Observes ShutdownEvent ev) {
-    }
- 
-    public void spool(String statClass, 
-    		String smppAccountId, 
-    		List<StatEnum> enums, 
-    		Instant ts, 
-    		Integer increment) throws JMSException {
-    	
-    	List<StatEnum> statEnums = new ArrayList<StatEnum>(enums.size());
-    	for (StatEnum se: enums) {
-    		statEnums.add(CommonStatEnum.build(se.getIndex(), se.getValue()));
-    	}
-    	StatEvent event = new StatEvent();
-    	event.setEntityId(smppAccountId);
-    	event.setEnums(statEnums);
-    	event.setIncrement(increment);
-    	event.setTs(ts);
-    	event.setStatClass(statClass);
-    	
-    	if ((enums == null)
-    			|| (enums.size() == 0)
-    			|| ( smppAccountId == null)
-    			|| (ts == null)
-    			|| (increment == null)
-    			|| (statClass == null)
-    			) {
-    		try {
-				logger.warn("spool: ignoring, check attributes: " + JsonUtil.serialize(event, false));
-			} catch (JsonProcessingException e) {
-			}
-    	} else {
-    		this.spool(event);
-    	}
-    }
-    
-    public void spool(
-    		String statClass, 
-    		String smppAccountId, 
-    		StatEnum statEnum, 
-    		Instant ts, 
-    		Integer increment, Double doubleIncrement) throws JMSException {
-    	
-    	StatEvent event = new StatEvent();
-    	event.setEntityId(smppAccountId);
-    	List<StatEnum> statEnums = new ArrayList<StatEnum>(1);
-    	statEnums.add(CommonStatEnum.build(statEnum.getIndex(), statEnum.getValue()));
-    	event.setEnums(statEnums);
-    	event.setIncrement(increment);
-    	event.setDoubleIncrement(doubleIncrement);
-    	event.setTs(ts);
-    	event.setStatClass(statClass);
-    	
-    	if ((statEnums == null)
-    			|| (statEnums.size() == 0)
-    			|| ( smppAccountId == null)
-    			|| (ts == null)
-    			|| (increment == null)
-    			|| (statClass == null)
-    			) {
-    		try {
-				logger.warn("spool: ignoring, check attributes: " + JsonUtil.serialize(event, false));
-			} catch (JsonProcessingException e) {
-	  		}
-    	} else {
-    		this.spool(event);
-      	}
-    }
-    
-    public void spool(StatEvent event) throws JMSException {
-    	this.spool(event, 0);
-    }
-    public void spool(StatEvent event, int attempt) throws JMSException {
-    	
-    	JMSProducer producer = null;
-    	JMSContext context = null;
-    	boolean retry = false;
-    	
-    	try {
-    		Pair<Integer, Pair<JMSContext, JMSProducer>> jms = getProducer(connectionFactory, isDebugEnabled());
-    		
-    		producer = jms.getRight().getRight();
-    		context = jms.getRight().getLeft();
-    		id = jms.getLeft();
-    		ObjectMessage message = context.createObjectMessage(event);
-        	synchronized (producer) {
-        		Queue queue = this.getQueue(context);
-        		producer.send(queue, message);
-            	message.acknowledge();
-        	}
-        	
-        	if (isDebugEnabled()) {
-        		try {
-    				logger.info("spool: stat event spooled to " + ServiceConfig.QUEUENAME + ":" + JsonUtil.serialize(event, false));
-    			} catch (JsonProcessingException e) {
-    				logger.error("", e);
-      			}
-        	}
-    	} catch (Exception e) {
-    		this.purgeAllProducers();
-   			logger.error("error", e);
- 			attempt++;
- 			if (attempt<ServiceConfig.POOLSIZE) {
- 				logger.info("spool: will retry attempt #" + attempt);
- 				retry = true;
- 			} else {
- 				throw (e);
- 	  		}
-    	}
-    	if (retry) this.spool(event, attempt);
-    }
-
-  private Queue queue = null;
-	private Queue getQueue(JMSContext context) {
-		if (queue == null) {
-			queue = context.createQueue(ServiceConfig.QUEUENAME);
-		}
-		return queue;
-	}
-}
-```
-
-
-## Sending Statistics to Accumulate
-To send statistics for accumulation, use the following parameters:
 ```java
 statProducer.spool(
-	FriendChatClass.ANIMATOR.toString(),
-	entityId, 
-	AnimatorStat.SENT_MSGS, 
-	Instant.now(), 
-	1);
+    FriendChatClass.ANIMATOR.toString(), // stat class
+    entityId,                            // entity id (preferably a UUID)
+    AnimatorStat.SENT_MSGS,              // counter to increment
+    Instant.now(),                       // timestamp
+    1);                                  // increment
 ```
-Here, `FriendChatClass.ANIMATOR` represents the type of statistics class, `entityId` is the associated entity (preferably a UUID), `AnimatorStat.SENT_MSGS` is the specific statistic to accumulate, `Instant.now()` is the timestamp, and `1` is the increment.
+
+The shared `StatEvent` / `StatEnum` types come from the `stats-api` dependency. Access to that artifact (and to `mobiera-commons`) requires the appropriate Maven repository credentials, configured either in `settings.xml` or as environment variables.
+
+## Build & run
+
+Dev mode (live reload, Swagger UI on port 8700):
+
+```bash
+./mvnw quarkus:dev
+```
+
+Package the application:
+
+```bash
+./mvnw package
+# runnable with:
+java -jar target/quarkus-app/quarkus-run.jar
+```
+
+Native executable:
+
+```bash
+./mvnw package -Pnative
+# or, without a local GraalVM:
+./mvnw package -Pnative -Dquarkus.native.container-build=true
+```
+
+## Container image
+
+CI builds and pushes the image to Docker Hub as `mobiera/stats` (`src/main/docker/Dockerfile.jvm`).
+
+- Push to `main` → tag `main`
+- Push to `dev` → tag `dev`
+- Release `vX.Y.Z` → tag `X.Y.Z`
+
+Run locally:
+
+```bash
+docker run --rm -p 8700:8080 \
+  -e QUARKUS_DATASOURCE_JDBC_URL=jdbc:postgresql://db/aircast \
+  -e QUARKUS_DATASOURCE_USERNAME=aircast \
+  -e QUARKUS_DATASOURCE_PASSWORD=... \
+  -e ARTEMIS_HOST=artemis \
+  -e ARTEMIS_PASSWORD=... \
+  mobiera/stats:main
+```
+
+## License
+
+Apache License 2.0 — see [LICENSE](./LICENSE).


### PR DESCRIPTION
## Summary

Rewrites `README.md` from scratch (in English) as proper **container** documentation, derived from the actual source (`application.properties`, the JMS consumer, the `Stat` JPA model, and the CI workflow).

## Contents

- Describes `stats` as a Quarkus container that consumes `StatEvent` from `stats-queue`, aggregates time-bucketed counters (hour/day/month) into the `stat` table, and serves a read-only REST query API.
- Documents the `/stats/view`, `/stats/compare`, `/stats/sumLastNStatVO`, `/stats/get` endpoints + Swagger UI (port 8700).
- Config/env-var tables (application, queue, database), Artemis 1–8 multi-instance setup.
- Producer example, build/run instructions, and the Docker Hub image `mobiera/stats`.