### PR TITLE
fix: address concurrency races in stats aggregation

### DIFF
--- a/src/main/java/com/mobiera/ms/commons/stats/svc/StatBuilderService.java
+++ b/src/main/java/com/mobiera/ms/commons/stats/svc/StatBuilderService.java
@@ -57,7 +57,7 @@ public class StatBuilderService {
 	
 	private static Logger logger = Logger.getLogger(StatBuilderService.class);
 	private static Map<String, Map<String, Map<StatGranularity, Map<Instant, Stat>>>> stats;
-	private static boolean startedService = false;
+	private static volatile boolean startedService = false;
 	
 	
 	public boolean isDebugEnabled() {
@@ -311,8 +311,9 @@ public class StatBuilderService {
 								if (raceStat == null) {
 									dateStats.put(stateDateTime, stat);
 									if (this.isDebugEnabled()) logger.info("getStat: CREATED: entityId: " + entityId + " stat: " + stat  + " stateDateTime: " + stateDateTime + " statGranularity: " + statGranularity);
-								} {
-									logger.warn("getStat: Not CREATED: entityId: " + entityId + " stat: " + stat  + " stateDateTime: " + stateDateTime + " statGranularity: " + statGranularity);
+								} else {
+									stat = raceStat;
+									if (this.isDebugEnabled()) logger.info("getStat: Not CREATED, using cached race winner: entityId: " + entityId + " stat: " + stat  + " stateDateTime: " + stateDateTime + " statGranularity: " + statGranularity);
 								}
 								
 							}
@@ -336,10 +337,12 @@ public class StatBuilderService {
 	}
 	
 	
-	public void init(ZoneId tz) {
+	public synchronized void init(ZoneId tz) {
 		this.tz = tz;
 		
-		stats = new ConcurrentHashMap<String, Map<String, Map<StatGranularity, Map<Instant, Stat>>>>(5);
+		if (stats == null) {
+			stats = new ConcurrentHashMap<String, Map<String, Map<StatGranularity, Map<Instant, Stat>>>>(5);
+		}
 		//em.find(Stat.class, "1");
 	}
 

--- a/src/main/java/com/mobiera/ms/commons/stats/svc/StatController.java
+++ b/src/main/java/com/mobiera/ms/commons/stats/svc/StatController.java
@@ -78,13 +78,27 @@ public class StatController {
 	
 	private static final Logger logger = Logger.getLogger("StatController");
 
-	private static boolean startedPurge = true;
+	private static volatile boolean startedPurge = true;
 	
-	private boolean finished = false;
+	private volatile boolean finished = false;
 	
 	void onStart(@Observes StartupEvent ev) {
 		logger.info("onStart: starting");
 		//startStatConsumers();
+		
+		// Initialize the timezone and the in-memory stats map BEFORE marking the
+		// service as started, otherwise consumer threads can observe
+		// startedService==true and call getStat() while stats is still null (NPE),
+		// since startPurgeTask() runs asynchronously on the worker pool.
+		if (tz == null) {
+			try {
+				tz = ZoneId.of(timezoneName);
+			} catch (Exception e) {
+				logger.error("onStart: invalid com.mobiera.ms.commons.stats.timezone: " + timezoneName);
+				throw(e);
+			}
+		}
+		statService.init(tz);
 		
 		startPurgeTask();
 		statService.setStartedService(true);

--- a/src/main/java/com/mobiera/ms/commons/stats/svc/StatReaderService.java
+++ b/src/main/java/com/mobiera/ms/commons/stats/svc/StatReaderService.java
@@ -66,15 +66,17 @@ public class StatReaderService {
 	@ConfigProperty(name = "com.mobiera.ms.commons.stats.in.memory.past.units")
 	Integer inMemoryPastUnits;
 	
-	private static NumberFormat nf = null;
+	// NumberFormat is not thread-safe; the reader service is hit by multiple
+	// concurrent REST threads, so use a per-thread instance.
+	private static final ThreadLocal<NumberFormat> nf = ThreadLocal.withInitial(() -> {
+		NumberFormat instance = NumberFormat.getInstance();
+		instance.setMaximumIntegerDigits(20);
+		instance.setMaximumFractionDigits(2);
+		return instance;
+	});
 	
 	private NumberFormat getNf() {
-		if (nf == null) {
-			nf = NumberFormat.getInstance();
-			nf.setMaximumIntegerDigits(20);
-			nf.setMaximumFractionDigits(2);
-		}
-		return nf;
+		return nf.get();
 	}
 	
 	private List<String> buildHeader(List<StatEnum> enums) {


### PR DESCRIPTION
## Summary

Fixes several concurrency / correctness issues found during a review of the stat ingest + aggregation path. Scoped to the low-risk, high-value set; compiles cleanly (`./mvnw clean compile`).

## Fixes

### 1. Lost-update race in `StatBuilderService.getStat` (data loss)
When two threads created the same `statClass/entity/granularity/ts` bucket concurrently, the race loser returned its **own orphaned `Stat`** instance (never put in the cache) instead of the winner already in the map. Its increments were silently dropped at flush. Also the `} {` block was an unconditional block, not an `else`, so the "Not CREATED" warning always fired. Now the loser reuses the cached `raceStat`.

### 2. Startup ordering NPE race in `StatController.onStart`
`setStartedService(true)` ran synchronously while `statService.init(tz)` (which allocates the static `stats` map) ran **asynchronously** inside `startPurgeTask()`. A consumer could observe `startedService==true` and call `getStat()` while `stats` was still `null` → NPE. `onStart` now resolves the timezone and calls `init(tz)` before `setStartedService(true)`. `init()` is now `synchronized` and idempotent (only allocates if null) so the later call from the purge task is harmless.

### 3. `NumberFormat` thread-safety in `StatReaderService`
`NumberFormat` is not thread-safe and was a shared `static` used by concurrent `/stats/view` and `/stats/compare` requests. Replaced with a `ThreadLocal<NumberFormat>`.

### 4. Missing `volatile` on cross-thread lifecycle flags
`startedService` (`StatBuilderService`), `startedPurge` and `finished` (`StatController`) are written/read across threads outside synchronized blocks; `finished` is spun on during shutdown. Marked `volatile` to guarantee visibility (fixes a potential shutdown hang).

## Not included (tracked for a separate, more careful change)
- Shared `EntityManager` used across consumer/flush/reader threads.
- Flush vs increment lock-identity desync via `removeLockObj`.
- `flushStats(statClass, entityId)` not holding the per-stat lock.
- Null `stat` NPE swallowed in `flushStats`.
- `StatServerResource.computeGranularity` dereferencing `from`/`to` before the null checks (returns 500 instead of 400).

## Test plan
- `./mvnw clean compile` passes.
- No behavior change to the public REST contract.