### PR TITLE
fix: harden stat flush locking and request validation

### DIFF
--- a/src/main/java/com/mobiera/ms/commons/stats/res/s/StatServerResource.java
+++ b/src/main/java/com/mobiera/ms/commons/stats/res/s/StatServerResource.java
@@ -81,13 +81,10 @@ public class StatServerResource {
 		
 		Response.Status status = Response.Status.BAD_REQUEST;
 
-		request.setStatGranularity(this.computeGranularity(request.getFrom(), request.getTo()));
-
 		if ((request.getFrom() == null) ||
 				(request.getTo() == null) ||
 				(request.getStatClass() == null) ||
 				(request.getStatEnums() == null) ||
-				(request.getStatGranularity() == null) ||
 				(request.getStatResultType() == null) ||
 				(request.getStatEnums().size() == 0)
 				) {
@@ -96,7 +93,9 @@ public class StatServerResource {
 
 		} else {
 
-			
+			// Derive granularity only after from/to are validated; computeGranularity
+			// dereferences both, so doing it first would NPE (500) on a bad request.
+			request.setStatGranularity(this.computeGranularity(request.getFrom(), request.getTo()));
 			try {
 				answer = statReaderService.getStatViewVO(request.getFrom(),
 						request.getTo(), request.getEntityIds()==null?new ArrayList<String>(0):request.getEntityIds(),
@@ -122,20 +121,21 @@ public class StatServerResource {
 	@Consumes(MediaType.APPLICATION_JSON)
 	public Response getCompareStatViewRequest(CompareStatView request) throws JsonProcessingException, InterruptedException
 	{
-		request.setStatGranularity(this.computeGranularity(request.getFrom(), request.getTo()));
 		StatView answer = null;
 		Response.Status status = Response.Status.BAD_REQUEST;
 
 		if ((request.getFrom() == null) ||
 				(request.getTo() == null) ||
 				(request.getKpis() == null) ||
-				(request.getStatGranularity() == null) ||
 				(request.getStatResultType() == null) ||
 				(request.getKpis().size() == 0)
 				) {
 			status = Status.BAD_REQUEST;
 		} else {
 
+			// Derive granularity only after from/to are validated; computeGranularity
+			// dereferences both, so doing it first would NPE (500) on a bad request.
+			request.setStatGranularity(this.computeGranularity(request.getFrom(), request.getTo()));
 			try {
 				answer = statReaderService.getCompareStatViewVO(request.getFrom(),
 						request.getTo(), request.getKpis(),

--- a/src/main/java/com/mobiera/ms/commons/stats/svc/StatBuilderService.java
+++ b/src/main/java/com/mobiera/ms/commons/stats/svc/StatBuilderService.java
@@ -431,6 +431,13 @@ public class StatBuilderService {
 											
 										}
 										
+										if (stat == null) {
+											synchronized (dateStats) {
+												dateStats.remove(currentDateTime);
+											}
+											continue;
+										}
+										
 										if (shutdown) {
 											try {
 												Object statLockObj = this.getLockObj(stat.getLockObjId());
@@ -483,12 +490,13 @@ public class StatBuilderService {
 												Object statLockObj = this.getLockObj(stat.getLockObjId());
 												synchronized (statLockObj) {
 													stat = treatStatFlush(stat);
-													
-												}
-												
-												synchronized (dateStats) {
-													dateStats.put(currentDateTime, stat);
-
+													// Replace the cached instance while still holding the
+													// per-bucket lock so a concurrent increment cannot apply
+													// to the pre-merge instance and then be discarded (lost
+													// update) when the merged instance overwrites it.
+													synchronized (dateStats) {
+														dateStats.put(currentDateTime, stat);
+													}
 												}
 												
 											} catch (Exception e) {
@@ -547,8 +555,22 @@ public class StatBuilderService {
 										
 										synchronized (dateStats) {
 											stat = dateStats.get(currentDateTime);
+										}
+										
+										if (stat == null) {
+											continue;
+										}
+										
+										// Use the same per-bucket lock discipline as the periodic
+										// flush so on-demand flushes and concurrent increments are
+										// mutually exclusive, and to keep a consistent
+										// statLockObj -> dateStats lock ordering (no deadlock).
+										Object statLockObj = this.getLockObj(stat.getLockObjId());
+										synchronized (statLockObj) {
 											stat = treatStatFlush(stat);
-											dateStats.put(currentDateTime, stat);
+											synchronized (dateStats) {
+												dateStats.put(currentDateTime, stat);
+											}
 										}
 										
 										


### PR DESCRIPTION
## Summary

Follow-up to #16, addressing 4 of the 5 hardening items tracked in #17. Compiles cleanly (`./mvnw clean compile`); no public REST contract change.

## Changes

### Request validation ordering (`StatServerResource`)
`/stats/view` and `/stats/compare` now validate `from`/`to` (and the other required fields) **before** calling `computeGranularity`, which dereferences both. Malformed requests now return `400 Bad Request` instead of a `500` (NPE).

### Defensive handling of concurrently-removed buckets (`StatBuilderService`)
Both flush methods now null-check the bucket fetched from the cache (it can be removed by a concurrent flush) and skip gracefully, instead of NPE-ing into a broad catch-all.

### Stable locking around the periodic flush (`StatBuilderService`)
In the non-evict branch, the per-bucket lock is now held **across** the flush and the cache replacement (`put`). This closes the window where a concurrent increment could be applied to the pre-merge instance and then discarded when the merged instance overwrote it (lost update).

### Consistent locking for on-demand flush (`StatBuilderService`)
`flushStats(statClass, entityId)` previously ran the flush under the `dateStats` monitor only. It now uses the same `statLockObj → dateStats` lock ordering as the periodic flush, so the two paths are mutually exclusive and consistent. Verified no code path acquires `dateStats` before a stat lock, so the ordering introduces no deadlock.

## Not included
- **Persistence-context / transaction boundaries** (item 1 in #17) intentionally deferred. Whether `@Transactional` is effective on the internally-invoked flush method depends on runtime behavior that needs a DB-backed test; changing commit semantics here without that is risky. Tracked in #17.

## Test plan
- `./mvnw clean compile` passes.
- Lock-ordering reviewed: increments hold only the per-bucket lock; `getStat` holds `dateStats` but never acquires a stat lock inside it; flush now consistently takes `statLockObj` then `dateStats`.

Refs #17