### PR TITLE
fix(docker): run on Java 25 base (fixes UnsupportedClassVersionError)

### DIFF
--- a/src/main/docker/Dockerfile.jvm
+++ b/src/main/docker/Dockerfile.jvm
@@ -75,7 +75,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi8/openjdk-17:1.18
+FROM registry.access.redhat.com/ubi9/openjdk-25:1.24
 
 ENV LANGUAGE='en_US:en'
 


### PR DESCRIPTION
## Problem

The `stats` container crashed at startup:

```
UnsupportedClassVersionError: com/mobiera/ms/commons/stats/assembler/StatVOAssembler
has been compiled by a more recent version of the Java Runtime (class file version 69.0),
this version of the Java Runtime only recognizes class file versions up to 61.0
```

Class file **69.0 = Java 25**, **61.0 = Java 17**.

## Cause

The app compiles to Java 25 (`maven.compiler.release=25`, built with `maven:3-eclipse-temurin-25`), but `src/main/docker/Dockerfile.jvm` ran on `registry.access.redhat.com/ubi8/openjdk-17`. A Java 17 runtime can't load Java 25 bytecode.

## Fix

Bump the runtime base to `registry.access.redhat.com/ubi9/openjdk-25:1.24` — the same base already used by `pm-model`.