### PR TITLE
ci: publish :dev on main, :main + :vA.B.C on release

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,21 +1,23 @@
 name: CI/CD Pipeline
 
+# Tagging policy:
+#   - push to main  -> Docker Hub image tagged :dev (this workflow)
+#   - GitHub release -> Docker Hub images tagged :main and :vA.B.C (release-please.yml)
+# Releases are created by release-please with the default GITHUB_TOKEN, which
+# does NOT trigger this workflow, so the release images are built there.
 on:
   push:
-    branches: [ main, dev ]
-    tags: [ 'v*' ]
+    branches: [ main ]
   pull_request:
     branches: [ main ]
-  release:
-    types: [ published ]
 
 env:
   DOCKER_DRIVER: overlay2
   DOCKER_TLS_CERTDIR: ""
   # Docker Hub image (public): mobiera/<repo>
   IMAGE: "mobiera/${{ github.event.repository.name }}"
-  # Default tag is main, will be overridden based on branch/tag
-  IMAGE_TAG: "main"
+  # main pushes publish the :dev image.
+  IMAGE_TAG: "dev"
 
 jobs:
   build:
@@ -26,22 +28,6 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-
-    - name: Set image tag
-      run: |
-        # If it's not main branch, use branch name as tag
-        if [[ "${{ github.ref_name }}" != "main" && "${{ github.ref_type }}" == "branch" ]]; then
-          echo "IMAGE_TAG=${{ github.ref_name }}" >> $GITHUB_ENV
-        # If it's a tag (not empty), use tag name without 'v' prefix
-        elif [[ "${{ github.ref_type }}" == "tag" ]]; then
-          echo "IMAGE_TAG=$(echo "${{ github.ref_name }}" | sed 's/v//')" >> $GITHUB_ENV
-        fi
-
-    - name: Log tag info
-      run: |
-        echo "Tag: ${{ github.ref_name }}"
-        echo "Branch: ${{ github.ref_name }}"
-        echo "Image Tag: ${{ env.IMAGE_TAG }}"
 
     - name: Create Maven settings directory
       run: |
@@ -80,21 +66,11 @@ jobs:
   docker-package:
     runs-on: ubuntu-latest
     needs: build
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev' || github.event_name == 'release'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
 
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-
-    - name: Set image tag
-      run: |
-        # If it's not main branch, use branch name as tag
-        if [[ "${{ github.ref_name }}" != "main" && "${{ github.ref_type }}" == "branch" ]]; then
-          echo "IMAGE_TAG=${{ github.ref_name }}" >> $GITHUB_ENV
-        # If it's a tag (not empty), use tag name without 'v' prefix
-        elif [[ "${{ github.ref_type }}" == "tag" ]]; then
-          echo "IMAGE_TAG=$(echo "${{ github.ref_name }}" | sed 's/v//')" >> $GITHUB_ENV
-        fi
 
     - name: Download build artifacts
       uses: actions/download-artifact@v4
@@ -167,7 +143,7 @@ jobs:
   security-scan:
     runs-on: ubuntu-latest
     needs: docker-package
-    if: github.ref == 'refs/heads/main' || github.event_name == 'release'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
 
     steps:
     - name: Checkout code

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -71,7 +71,9 @@ jobs:
 
       - name: Build and push container image
         run: |
-          VERSION="${TAG_NAME#v}"
-          echo "Building ${IMAGE}:${VERSION} from tag ${TAG_NAME}"
-          docker build -f src/main/docker/Dockerfile.jvm -t "${IMAGE}:${VERSION}" .
-          docker push "${IMAGE}:${VERSION}"
+          echo "Building ${IMAGE}:main and ${IMAGE}:${TAG_NAME} from tag ${TAG_NAME}"
+          docker build -f src/main/docker/Dockerfile.jvm \
+            -t "${IMAGE}:main" \
+            -t "${IMAGE}:${TAG_NAME}" .
+          docker push "${IMAGE}:main"
+          docker push "${IMAGE}:${TAG_NAME}"


### PR DESCRIPTION
Aligns CI/CD with the pm-model tagging policy, adapted for Docker Hub (`mobiera/stats`).

## Changes
- **ci-cd.yml**: pushes to `main` build and push `mobiera/stats:dev` (was `:main`). Removed `dev`-branch/tag/`release` triggers and the per-branch "Set image tag"/"Log tag info" steps. PRs build + test without pushing. Trivy scans `:dev`.
- **release-please.yml**: on `release_created`, build and push **both** `mobiera/stats:main` (stable) and the versioned `mobiera/stats:vA.B.C` tag.

## Policy
- push to `main` -> `:dev`
- GitHub release -> `:main` + `:vA.B.C`

Docker Hub `IMAGE` and the existing Maven/Docker build steps are preserved. YAML validated.